### PR TITLE
Fix user index integration text

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
 
   def index
     @user = current_user
-    if @user && @user.admin? 
+    if @user.admin? 
       @users = User.where(activated: true).paginate(page: params[:page])
     else
       @users = User.where("role = :role and activated = :activated", { role: "2", activated: true }).paginate(page: params[:page])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,13 +2,13 @@ class UsersController < ApplicationController
 
   include SessionsHelper
 
-  before_action :logged_in_user, only: [:sellerIndex, :edit, :update, :destroy]
+  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
   before_action :correct_user,   only: [:edit, :update]
   before_action :admin_user,     only: :destroy
 
   def index
     @user = current_user
-    if @user.admin? 
+    if @user && @user.admin? 
       @users = User.where(activated: true).paginate(page: params[:page])
     else
       @users = User.where("role = :role and activated = :activated", { role: "2", activated: true }).paginate(page: params[:page])

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -60,7 +60,7 @@ random_user_<%= n %>:
   name:  <%= "User #{n}" %>
   email: <%= "user-#{n}@mail.com" %>
   password_digest: <%= User.digest('password') %>
-  role: 1
+  role: <%= "#{n%2+1}" %>
   activated: true
   activated_at: <%= Time.zone.now %>
 <% end %>

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -8,13 +8,12 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     @unactivated_user = users(:unactivated_user)
   end
 
-  test "index including pagination" do
+  test "index as non-admin should have only vendor users" do
     log_in_as(@user)
     get users_path
     assert_template 'users/index'
-    assert_select 'div.pagination'
     User.paginate(page: 1).each do |user|
-      if user.activated
+      if user.vendor?
         assert_select 'a[href=?]', user_path(user), text: user.name
       else
         assert_select 'a[href=?]', user_path(user), text: user.name, count: 0
@@ -43,7 +42,7 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "index as non-admin" do
+  test "index as non-admin should not have delete links" do
     log_in_as(@user)
     get users_path
     assert_select 'a', text: 'delete', count: 0


### PR DESCRIPTION
When the user index of non-admin users was changed to show only vendor users, we had troubles with the integration test, i decided to change the test verifying that there are no buyer users on the first page of users, please tell me if you are agree with that.

Also when you were implementing the mentioned feature, you had the idea of changing the action 'index' for 'sellerIndex', you forgot to change it back on the verification of logged_in_user, as you can see in the user controller file. 

I noticed this errors after running the tests, remember to run all the tests before pushing a commit.